### PR TITLE
Changing transformers version bounds to support stack LTS 8.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.stack-work

--- a/break.cabal
+++ b/break.cabal
@@ -23,7 +23,7 @@ Library
     Build-Depends:
         base         >= 4.5     && < 5  ,
         mtl                             ,
-        transformers >= 0.4.0.0 && < 0.5
+        transformers >= 0.4.0.0 && < 0.6
     Exposed-Modules: Control.Break
     GHC-Options: -O2 -Wall
     Default-Language: Haskell2010


### PR DESCRIPTION
Hi Gabriel,

Just a small version bump. Having problems compiling break-1.0.x in stack via LTS-8.x because of the transformers version bounds.

This fixes it when I add it to my stack.yaml and compile locally.

Thanks